### PR TITLE
fix cli

### DIFF
--- a/calligraphy-cli/calligraphy-cli.cabal
+++ b/calligraphy-cli/calligraphy-cli.cabal
@@ -39,7 +39,7 @@ maintainer:         dominic.millz27@gmail.com
 extra-source-files: CHANGELOG.md
 
 
-executable  calligraphy-cli
+executable calligraphy-cli
     main-is: Main.hs
     build-depends:    base ^>=4.16.4.0
                     , optparse-applicative ^>=0.17.0.0
@@ -48,29 +48,4 @@ executable  calligraphy-cli
                     , text 
                     , directory
     hs-source-dirs: src/
-
-library
-    -- Modules exported by the library.
-    exposed-modules:  Main
-
-    -- Modules included in this library but not exported.
-    -- other-modules:
-
-    -- LANGUAGE extensions used by modules in this package.
-    -- other-extensions:
-
-    -- Other library packages from which modules are imported.
-    build-depends:    base ^>=4.16.4.0
-                    , optparse-applicative ^>=0.17.0.0
-                    , process
-                    , text 
-                    , directory
-                    , calligraphy == 0.1.6
-
-                     
-
-    -- Directories containing source files.
-    hs-source-dirs:   src
-
-    -- Base language which the package is written in.
     default-language: Haskell2010

--- a/src/Calligraphy/Compat/GHC.hs
+++ b/src/Calligraphy/Compat/GHC.hs
@@ -28,6 +28,7 @@ module Calligraphy.Compat.GHC
     getKey,
     getOccString,
     hieVersion,
+    version,
     initNameCache,
     mkSplitUniqSupply,
     moduleName,
@@ -59,6 +60,7 @@ import GHC.Types.Name
 import GHC.Types.Unique
 import GHC.Types.Unique.Supply
 import GHC.Unit.Types
+import Paths_calligraphy (version)
 #else
 import Avail
 import GHC
@@ -70,4 +72,5 @@ import NameCache
 import SrcLoc
 import UniqSupply
 import Unique
+import Paths_calligraphy (version)
 #endif


### PR DESCRIPTION
- I remove the library from calligraphy-cli as this package is only an executable, not library + executable
- Most of  `XXXXConfig` data types are defined already in calligraphy package, so you don't need to define again
- The Paths_calligraphy things, still bugs me. I don't know why I can't use it in `calligraphy-cli`. I did a dirty hack of exporting it in a `calligraphy` module so It is available for other packagesa